### PR TITLE
Allow using up to 8GB of ram in a meteor build by default, make it configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,13 +81,16 @@ to build your application for Meteor mobile integration.
 
 ### Memory in the build process
 
+Meteor build is handled by a Node.JS process which has a default limit:
+it can't use more than ~3.7GB of RAM. It can be too little for large Meteor
+applications and the build process will fail with the following error:
+`Allocation failed`.
 
-By default the node process can only use ~3.7GB of RAM during the build process
-which can'y be too little for large Meteor application, that's why the
-buildpack is adding to the environment variable `TOOL_NODE_FLAGS`, the flag
-`--max-old-space-size=8192` (except if this precise flag is already defined).
-If the variable does not exist it is initialized. To update the value `8192`,
-the variable `BUILD_MAX_MEMORY` can be overriden.
+The buildpack is fixing this issue by adding to the environment variable
+`TOOL_NODE_FLAGS`, the flag `--max-old-space-size=8192` (except if this
+precise flag is already defined).
+
+To update the value `8192`, the variable `BUILD_MAX_MEMORY` can be overriden.
 
 ### Starting flags for `node` process
 

--- a/README.md
+++ b/README.md
@@ -79,6 +79,16 @@ make your application work, out of the box.
 If you are using Meteor ≥ 1.3, the flag `--server-only` will be used automatically
 to build your application for Meteor mobile integration.
 
+### Memory in the build process
+
+
+By default the node process can only use ~3.7GB of RAM during the build process
+which can'y be too little for large Meteor application, that's why the
+buildpack is adding to the environment variable `TOOL_NODE_FLAGS`, the flag
+`--max-old-space-size=8192` (except if this precise flag is already defined).
+If the variable does not exist it is initialized. To update the value `8192`,
+the variable `BUILD_MAX_MEMORY` can be overriden.
+
 ### Starting flags for `node` process
 
 For some reasons, you may want to use custom flags to run your application.

--- a/bin/compile
+++ b/bin/compile
@@ -241,6 +241,7 @@ cache_build | output "$LOG_FILE"
 # Build meteor app if required
 if test -n "$meteor_version"; then
   header "Meteor app detected: version ${meteor_version}"
+  setup_meteor_build_environment
   build_meteor_app $BUILD_DIR $CACHE_DIR
 fi
 

--- a/bin/meteor.sh
+++ b/bin/meteor.sh
@@ -37,6 +37,14 @@ meteor_npm_version() {
   fi
 }
 
+setup_meteor_build_environment() {
+  tnf="${TOOL_NODE_FLAGS}"
+  if echo $tnf | grep -v -q 'max-old-space-size' ; then
+    mem=${BUILD_MAX_MEMORY:-8192}
+    export TOOL_NODE_FLAGS="${tnf} --max-old-space-size=${mem}"
+  fi
+}
+
 create_meteor_settings_profile() {
   local build_dir=$1
   local settings=""


### PR DESCRIPTION
Fixes #19