### PR TITLE
Do not display dangerous semver range if both greater than and lesser than are used

### DIFF
--- a/lib/failure.sh
+++ b/lib/failure.sh
@@ -314,7 +314,7 @@ warn_node_engine() {
   elif [ "$node_engine" == "*" ]; then
     warning "Dangerous semver range (*) in engines.node" "http://doc.scalingo.com/languages/javascript/nodejs#specifying-a-nodejs-version"
     mcount 'warnings.node.star'
-  elif [ ${node_engine:0:1} == ">" ]; then
+  elif [ ${node_engine:0:1} == ">" -a "$(echo $node_engine | grep -c '<')" -eq 0 ]; then
     warning "Dangerous semver range (>) in engines.node" "http://doc.scalingo.com/languages/javascript/nodejs#specifying-a-nodejs-version"
     mcount 'warnings.node.greater'
   fi


### PR DESCRIPTION
Fixes #27

Allow the following:

```
{
  "engines": {
    "node": ">10 <12"
  }
}
```