### PR TITLE
[Meteor] Fix default Node.js version + support 1.10

### DIFF
--- a/bin/meteor.sh
+++ b/bin/meteor.sh
@@ -17,7 +17,9 @@ get_meteor_minor_version() {
 # Format of .meteor/release file is METEOR@1.4.x-patchsomething
 meteor_node_version() {
   minor=$(get_meteor_minor_version)
-  if [ "$minor" -ge 9 ] ; then
+  if [ "$minor" -ge 10 ] ; then
+    echo "12.16.x"
+  elif [ "$minor" -ge 9 ] ; then
     echo "12.16.x"
   elif [ "$minor" -ge 8 ] ; then
     echo "8.16.x"

--- a/bin/meteor.sh
+++ b/bin/meteor.sh
@@ -18,7 +18,7 @@ get_meteor_minor_version() {
 meteor_node_version() {
   minor=$(get_meteor_minor_version)
   if [ "$minor" -ge 9 ] ; then
-    echo "13.7.x"
+    echo "12.16.x"
   elif [ "$minor" -ge 8 ] ; then
     echo "8.16.x"
   elif [ "$minor" -ge 6 ] ; then


### PR DESCRIPTION
- [Meteor] Add support for Meteor 1.10.x
- [Meteor] Install Node.js 12.16.x with Meteor 1.9.x (and not 13.x)

Notify https://app.intercom.com/a/apps/w4oogu7s/inbox/inbox/all/conversations/12375700004271 when in prod.

Fix #37